### PR TITLE
fix: update README to use the correct image URL for repo banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+<p align="center">
+  <img src="https://github.com/Use-Tusk/drift-python-sdk/raw/master/images/tusk-banner.png" alt="Tusk Drift Banner">
+</p>
+
+<div align="center">
+
+[![X URL](https://img.shields.io/twitter/url?url=https%3A%2F%2Fx.com%2Fusetusk&style=flat&logo=x&label=Tusk&color=BF40BF)](https://x.com/usetusk)
+[![Slack URL](https://img.shields.io/badge/slack-badge?style=flat&logo=slack&label=Tusk&color=BF40BF)](https://join.slack.com/t/tusk-community/shared_invite/zt-3fve1s7ie-NAAUn~UpHsf1m_2tdoGjsQ)
+
+</div>
+
 # Drift Python SDK
 
 Python SDK for Tusk Drift instrumentation and replay.


### PR DESCRIPTION
Switched from `main` to `master`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the README banner by pointing the image to the master branch so it renders on GitHub. Also added centered X and Slack badges with links.

<sup>Written for commit cd5698c52b11bf6bdff25d1a1b781d9a8f95b94c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

