### PR TITLE
docs: remove framework support installation instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,19 +69,6 @@ After completing the CLI wizard, install the SDK:
 pip install tusk-drift-python-sdk
 ```
 
-#### With Framework Support
-
-```bash
-# With Flask support
-pip install tusk-drift-python-sdk[flask]
-
-# With FastAPI support
-pip install tusk-drift-python-sdk[fastapi]
-
-# With Django support
-pip install tusk-drift-python-sdk[django]
-```
-
 ### Step 3: Initialize the SDK for your service
 
 Refer to our [initialization guide](docs/initialization.md) to set up the SDK for your service.


### PR DESCRIPTION
Framework-specific installation commands no longer required because we have the `--eligibility-only` flag for the Tusk Drift onboarding agent (see PR: https://github.com/Use-Tusk/tusk-drift-cli/pull/104)