### PR TITLE
fix: gracefully handle missing mocks for pre-app-start queries in replay mode

### DIFF
--- a/drift/instrumentation/psycopg/instrumentation.py
+++ b/drift/instrumentation/psycopg/instrumentation.py
@@ -563,6 +563,10 @@ class PsycopgInstrumentation(InstrumentationBase):
         """Handle background requests in REPLAY mode - return cursor with empty mock data."""
         cursor._mock_rows = []  # pyright: ignore
         cursor._mock_index = 0  # pyright: ignore
+        fetchone, fetchmany, fetchall = self._create_fetch_methods(cursor, "_mock_rows", "_mock_index")
+        cursor.fetchone = fetchone  # pyright: ignore[reportAttributeAccessIssue]
+        cursor.fetchmany = fetchmany  # pyright: ignore[reportAttributeAccessIssue]
+        cursor.fetchall = fetchall  # pyright: ignore[reportAttributeAccessIssue]
         return cursor
 
     def _replay_execute(self, cursor: Any, sdk: TuskDrift, query_str: str, params: Any, is_async: bool = False) -> Any:

--- a/drift/instrumentation/psycopg/instrumentation.py
+++ b/drift/instrumentation/psycopg/instrumentation.py
@@ -581,9 +581,17 @@ class PsycopgInstrumentation(InstrumentationBase):
 
             if mock_result is None:
                 is_pre_app_start = not sdk.app_ready
+                if is_pre_app_start:
+                    logger.warning(
+                        f"[Tusk REPLAY] No mock found for pre-app-start psycopg query, returning empty result. "
+                        f"Query: {query_str[:100]}..."
+                    )
+                    self._noop_execute(cursor)
+                    span_info.span.end()
+                    return cursor
                 raise RuntimeError(
                     f"[Tusk REPLAY] No mock found for psycopg execute query. "
-                    f"This {'pre-app-start ' if is_pre_app_start else ''}query was not recorded during the trace capture. "
+                    f"This query was not recorded during the trace capture. "
                     f"Query: {query_str[:100]}..."
                 )
 
@@ -742,12 +750,17 @@ class PsycopgInstrumentation(InstrumentationBase):
 
             if mock_result is None:
                 is_pre_app_start = not sdk.app_ready
-                logger.error(
-                    f"No mock found for {'pre-app-start ' if is_pre_app_start else ''}psycopg executemany query in REPLAY mode: {query_str[:100]}"
-                )
+                if is_pre_app_start:
+                    logger.warning(
+                        f"[Tusk REPLAY] No mock found for pre-app-start psycopg executemany query, returning empty result. "
+                        f"Query: {query_str[:100]}..."
+                    )
+                    self._noop_execute(cursor)
+                    span_info.span.end()
+                    return cursor
                 raise RuntimeError(
                     f"[Tusk REPLAY] No mock found for psycopg executemany query. "
-                    f"This {'pre-app-start ' if is_pre_app_start else ''}query was not recorded during the trace capture. "
+                    f"This query was not recorded during the trace capture. "
                     f"Query: {query_str[:100]}..."
                 )
 
@@ -1150,9 +1163,16 @@ class PsycopgInstrumentation(InstrumentationBase):
 
             if mock_result is None:
                 is_pre_app_start = not sdk.app_ready
+                if is_pre_app_start:
+                    logger.warning(
+                        f"[Tusk REPLAY] No mock found for pre-app-start psycopg stream query, returning empty result. "
+                        f"Query: {query_str[:100]}..."
+                    )
+                    span_info.span.end()
+                    return
                 raise RuntimeError(
                     f"[Tusk REPLAY] No mock found for psycopg stream query. "
-                    f"This {'pre-app-start ' if is_pre_app_start else ''}query was not recorded. "
+                    f"This query was not recorded. "
                     f"Query: {query_str[:100]}..."
                 )
 
@@ -1295,9 +1315,17 @@ class PsycopgInstrumentation(InstrumentationBase):
 
             if mock_result is None:
                 is_pre_app_start = not sdk.app_ready
+                if is_pre_app_start:
+                    logger.warning(
+                        f"[Tusk REPLAY] No mock found for pre-app-start psycopg copy operation, returning empty result. "
+                        f"Query: {query_str[:100]}..."
+                    )
+                    span_info.span.end()
+                    yield MockCopy(data=[])
+                    return
                 raise RuntimeError(
                     f"[Tusk REPLAY] No mock found for psycopg copy operation. "
-                    f"This {'pre-app-start ' if is_pre_app_start else ''}copy was not recorded. "
+                    f"This copy was not recorded. "
                     f"Query: {query_str[:100]}..."
                 )
 

--- a/drift/instrumentation/psycopg/instrumentation.py
+++ b/drift/instrumentation/psycopg/instrumentation.py
@@ -559,14 +559,32 @@ class PsycopgInstrumentation(InstrumentationBase):
             span_kind=OTelSpanKind.CLIENT,
         )
 
-    def _noop_execute(self, cursor: Any) -> Any:
+    def _noop_execute(self, cursor: Any, is_async: bool = False) -> Any:
         """Handle background requests in REPLAY mode - return cursor with empty mock data."""
         cursor._mock_rows = []  # pyright: ignore
         cursor._mock_index = 0  # pyright: ignore
         fetchone, fetchmany, fetchall = self._create_fetch_methods(cursor, "_mock_rows", "_mock_index")
-        cursor.fetchone = fetchone  # pyright: ignore[reportAttributeAccessIssue]
-        cursor.fetchmany = fetchmany  # pyright: ignore[reportAttributeAccessIssue]
-        cursor.fetchall = fetchall  # pyright: ignore[reportAttributeAccessIssue]
+        if is_async:
+            sync_fetchone, sync_fetchmany, sync_fetchall = fetchone, fetchmany, fetchall
+
+            async def async_fetchone():
+                return sync_fetchone()
+
+            async def async_fetchmany(size=None):
+                if size is None:
+                    size = cursor.arraysize
+                return sync_fetchmany(size)
+
+            async def async_fetchall():
+                return sync_fetchall()
+
+            cursor.fetchone = async_fetchone  # pyright: ignore[reportAttributeAccessIssue]
+            cursor.fetchmany = async_fetchmany  # pyright: ignore[reportAttributeAccessIssue]
+            cursor.fetchall = async_fetchall  # pyright: ignore[reportAttributeAccessIssue]
+        else:
+            cursor.fetchone = fetchone  # pyright: ignore[reportAttributeAccessIssue]
+            cursor.fetchmany = fetchmany  # pyright: ignore[reportAttributeAccessIssue]
+            cursor.fetchall = fetchall  # pyright: ignore[reportAttributeAccessIssue]
         return cursor
 
     def _replay_execute(self, cursor: Any, sdk: TuskDrift, query_str: str, params: Any, is_async: bool = False) -> Any:
@@ -590,7 +608,7 @@ class PsycopgInstrumentation(InstrumentationBase):
                         f"[Tusk REPLAY] No mock found for pre-app-start psycopg query, returning empty result. "
                         f"Query: {query_str[:100]}..."
                     )
-                    self._noop_execute(cursor)
+                    self._noop_execute(cursor, is_async=is_async)
                     span_info.span.end()
                     return cursor
                 raise RuntimeError(

--- a/drift/instrumentation/psycopg2/instrumentation.py
+++ b/drift/instrumentation/psycopg2/instrumentation.py
@@ -604,9 +604,17 @@ class Psycopg2Instrumentation(InstrumentationBase):
 
             if mock_result is None:
                 is_pre_app_start = not sdk.app_ready
+                if is_pre_app_start:
+                    logger.warning(
+                        f"[Tusk REPLAY] No mock found for pre-app-start psycopg2 query, returning empty result. "
+                        f"Query: {query_str[:100]}..."
+                    )
+                    self._noop_execute(cursor)
+                    span_info.span.end()
+                    return None
                 raise RuntimeError(
                     f"[Tusk REPLAY] No mock found for psycopg2 execute query. "
-                    f"This {'pre-app-start ' if is_pre_app_start else ''}query was not recorded during the trace capture. "
+                    f"This query was not recorded during the trace capture. "
                     f"Query: {query_str[:100]}..."
                 )
 
@@ -754,9 +762,17 @@ class Psycopg2Instrumentation(InstrumentationBase):
 
             if mock_result is None:
                 is_pre_app_start = not sdk.app_ready
+                if is_pre_app_start:
+                    logger.warning(
+                        f"[Tusk REPLAY] No mock found for pre-app-start psycopg2 executemany query, returning empty result. "
+                        f"Query: {query_str[:100]}..."
+                    )
+                    self._noop_execute(cursor)
+                    span_info.span.end()
+                    return None
                 raise RuntimeError(
                     f"[Tusk REPLAY] No mock found for psycopg2 executemany query. "
-                    f"This {'pre-app-start ' if is_pre_app_start else ''}query was not recorded during the trace capture. "
+                    f"This query was not recorded during the trace capture. "
                     f"Query: {query_str[:100]}..."
                 )
 

--- a/drift/instrumentation/redis/instrumentation.py
+++ b/drift/instrumentation/redis/instrumentation.py
@@ -431,9 +431,16 @@ class RedisInstrumentation(InstrumentationBase):
 
             if mock_result is None:
                 is_pre_app_start = not sdk.app_ready
+                if is_pre_app_start:
+                    logger.warning(
+                        f"[Tusk REPLAY] No mock found for pre-app-start Redis command, returning default response. "
+                        f"Command: {command_str}"
+                    )
+                    span_info.span.end()
+                    return self._get_default_response(command_name)
                 raise RuntimeError(
                     f"[Tusk REPLAY] No mock found for Redis command. "
-                    f"This {'pre-app-start ' if is_pre_app_start else ''}command was not recorded during the trace capture. "
+                    f"This command was not recorded during the trace capture. "
                     f"Command: {command_str}"
                 )
 
@@ -769,9 +776,16 @@ class RedisInstrumentation(InstrumentationBase):
 
             if mock_result is None:
                 is_pre_app_start = not sdk.app_ready
+                if is_pre_app_start:
+                    logger.warning(
+                        f"[Tusk REPLAY] No mock found for pre-app-start Redis pipeline, returning empty result. "
+                        f"Commands: {command_str}"
+                    )
+                    span_info.span.end()
+                    return []
                 raise RuntimeError(
                     f"[Tusk REPLAY] No mock found for Redis pipeline. "
-                    f"This {'pre-app-start ' if is_pre_app_start else ''}pipeline was not recorded during the trace capture. "
+                    f"This pipeline was not recorded during the trace capture. "
                     f"Commands: {command_str}"
                 )
 

--- a/drift/instrumentation/sqlalchemy/instrumentation.py
+++ b/drift/instrumentation/sqlalchemy/instrumentation.py
@@ -89,19 +89,26 @@ class SqlAlchemyInstrumentation(InstrumentationBase):
 
             if mock_result is None:
                 is_pre_app_start = not sdk.app_ready
-                span_info.span.set_status(
-                    Status(
-                        OTelStatusCode.ERROR,
-                        "No mock found for sqlalchemy query in replay",
+                if is_pre_app_start:
+                    logger.warning(
+                        f"[Tusk REPLAY] No mock found for pre-app-start sqlalchemy query, returning empty result. "
+                        f"Query: {query_str[:120]}..."
                     )
-                )
-                span_info.span.end()
-                instrumentation._reset_context_state(context)
-                raise RuntimeError(
-                    f"[Tusk REPLAY] No mock found for sqlalchemy query. "
-                    f"This {'pre-app-start ' if is_pre_app_start else ''}query was not recorded during the trace capture. "
-                    f"Query: {query_str[:120]}..."
-                )
+                    mock_result = {"rows": [], "rowcount": 0, "description": None}
+                else:
+                    span_info.span.set_status(
+                        Status(
+                            OTelStatusCode.ERROR,
+                            "No mock found for sqlalchemy query in replay",
+                        )
+                    )
+                    span_info.span.end()
+                    instrumentation._reset_context_state(context)
+                    raise RuntimeError(
+                        f"[Tusk REPLAY] No mock found for sqlalchemy query. "
+                        f"This query was not recorded during the trace capture. "
+                        f"Query: {query_str[:120]}..."
+                    )
 
             # Preserve error-path behavior in replay for queries recorded as failures.
             if isinstance(mock_result, dict):


### PR DESCRIPTION
### Summary

During replay mode, pre-app-start queries (e.g. Django's migration checks, table introspection) that weren't captured in the original trace would raise `RuntimeError`, crashing the replay. These framework-internal queries only occur with certain server configurations (e.g. `runserver` vs `gunicorn`) and are safe to return empty results for—Django handles "no tables found" gracefully.

This change makes all database and Redis instrumentations return a no-op/empty result for pre-app-start queries when no mock is found, instead of raising an error. Post-app-start queries with missing mocks still raise `RuntimeError` to catch genuine replay issues.

### Changes

- **psycopg2** (`instrumentation.py`): `_replay_execute` and `_replay_executemany` now delegate to `self._noop_execute(cursor)` for pre-app-start queries with no mock, logging a warning instead of raising.
- **psycopg** (`instrumentation.py`): Same fix applied to `_replay_execute`, `_replay_executemany`, `_replay_stream` (returns empty generator), and `_replay_copy` (yields empty `MockCopy`).
- **sqlalchemy** (`instrumentation.py`): `before_cursor_execute` sets `mock_result` to an empty result dict (`{"rows": [], "rowcount": 0, "description": None}`) for pre-app-start queries, allowing the normal `after_cursor_execute` flow to proceed.
- **redis** (`instrumentation.py`): `_replay_execute_command` returns `self._get_default_response(command_name)` (existing per-command-type defaults) and `_replay_pipeline_execute` returns `[]` for pre-app-start commands.