### PR TITLE
fix: add output schema merges to Django replay span

### DIFF
--- a/drift/instrumentation/django/middleware.py
+++ b/drift/instrumentation/django/middleware.py
@@ -274,9 +274,10 @@ class DriftMiddleware:
     def _capture_replay_output(self, request: HttpRequest, response: HttpResponse, span_info: SpanInfo) -> None:
         """Capture response data on the span for REPLAY mode.
 
-        Sets OUTPUT_VALUE so the inbound replay span sent to the CLI includes
-        the actual response for UI comparison. Skips RECORD-mode concerns like
-        transforms, trace blocking, and schema merges.
+        Sets OUTPUT_VALUE and OUTPUT_SCHEMA_MERGES so the inbound replay span
+        sent to the CLI includes the actual response with correct schema hints
+        for UI display. Skips RECORD-mode concerns like transforms and trace
+        blocking.
 
         Args:
             request: Django HttpRequest object
@@ -312,6 +313,9 @@ class DriftMiddleware:
         )
 
         span_info.span.set_attribute(TdSpanAttributes.OUTPUT_VALUE, json.dumps(output_value))
+
+        output_schema_merges = build_output_schema_merges(output_value)
+        span_info.span.set_attribute(TdSpanAttributes.OUTPUT_SCHEMA_MERGES, json.dumps(output_schema_merges))
 
     def _normalize_html_response(self, response: HttpResponse) -> HttpResponse:
         """Normalize HTML response body for REPLAY mode comparison.


### PR DESCRIPTION
### Summary

The Django middleware's replay code path (`_capture_replay_output`) was missing `OUTPUT_SCHEMA_MERGES` on the span, causing the Tusk UI to display raw base64-encoded response bodies instead of the decoded value when viewing replay results.

This is purely a **UI display bug** — CLI test results are unaffected and correctly report "no deviation." The CLI comparison flow never reads `outputSchema` from the replay span. It decodes the *recorded* span's body using the recorded schema (which has `encoding: BASE64`), then compares it against the raw HTTP response bytes from the actual replay request. Both sides resolve to the decoded value, so the comparison passes.

This issue is **Django-specific**. Flask/WSGI and FastAPI correctly set schema merges during replay

### Changes

- Add `OUTPUT_SCHEMA_MERGES` attribute to the replay span in `DriftMiddleware._capture_replay_output` so the downstream schema generator correctly annotates the body field with `encoding: BASE64`
- Update the method's docstring to reflect that schema merges are no longer skipped in the replay path